### PR TITLE
Fix warning about unused variables

### DIFF
--- a/AES.xs
+++ b/AES.xs
@@ -181,9 +181,9 @@ new(class, key_sv, ...)
     SV *  key_sv
 CODE:
     {
+        PERL_UNUSED_ARG(class);
         STRLEN keysize;
         unsigned char * key;
-        SV * self;
         HV * options = newHV();
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L
 #ifdef LIBRESSL_VERSION_NUMBER


### PR DESCRIPTION
GCC 14.1.1 with perl 5.38.2 warns:

~~~~
gcc -c  -I/usr/include -D_REENTRANT -D_GNU_SOURCE -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall   -DVERSION=\"0.20\" -DXS_VERSION=\"0.20\" -fPIC "-I/usr/lib64/perl5/CORE"   AES.c
AES.xs: In function ‘XS_Crypt__OpenSSL__AES_new’:
AES.xs:186:14: warning: unused variable ‘self’ [-Wunused-variable]
  186 |         SV * self;
      |              ^~~~
AES.c:328:17: warning: unused variable ‘class’ [-Wunused-variable]
  328 |         SV *    class = ST(0)
      |                 ^~~~~
~~~~

This patch fixes it.